### PR TITLE
Adds configuration option for displaying menu item

### DIFF
--- a/config/nova-media-hub.php
+++ b/config/nova-media-hub.php
@@ -43,6 +43,9 @@ return [
         'default',
     ],
 
+    // Defines whether the Nova menu item for Media Hub is shown
+    'enable_menu' => true,
+
     // Defines whether user can create collections in the "Upload media" modal
     // If set to false, the user can only use the collections defined in the config
     'user_can_create_collections' => true,

--- a/src/MediaHub.php
+++ b/src/MediaHub.php
@@ -31,6 +31,8 @@ class MediaHub extends Tool
 
     public function menu(Request $request)
     {
+        if (! config('nova-media-hub.enable_menu')) return;
+
         return MenuSection::make(__('novaMediaHub.navigationItemTitle'))
             ->path(self::getBasePath())
             ->icon('photograph');


### PR DESCRIPTION
This PR allows the Media Hub menu item in the Nova dashboard to be disabled if desired. A practical example is when requiring users to upload media to a default collection name that is dynamically generated in a Nova Resource.