### PR TITLE
Fix the problem with trimmed file name

### DIFF
--- a/src/MediaHandler/Support/FileHelpers.php
+++ b/src/MediaHandler/Support/FileHelpers.php
@@ -89,7 +89,11 @@ class FileHelpers
     {
         $name = pathinfo($fileName, PATHINFO_BASENAME);
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
-        $name = mb_substr($name, 0, - (mb_strlen($extension) + 1));
+
+        if (!empty($extension)) {
+            $name = mb_substr($name, 0, -(mb_strlen($extension) + 1));
+        }
+
         return [$name, $extension];
     }
 


### PR DESCRIPTION
Theres is a problem when media is created from a remote source. The last character of the original file name is trimmed.

To reproduce the issue run in a console: 

`php artisan tinker`

and then enter:

`\Outl1ne\NovaMediaHub\MediaHub::storeMediaFromUrl('https://picsum.photos/1920/1080.jpg', 'default');`

As a result a new file with wrong filename (108.jpg instead of 1080.jpg) is saved:
![image](https://user-images.githubusercontent.com/292668/203653994-9f7b603a-773b-49d5-9c32-dfab52a0a336.png)

That's because files saved in /tmp directory don't have an extension.

