### PR TITLE
Remove double URL encoding

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -39,7 +39,7 @@ class Media extends Model
 
     public function getUrlAttribute()
     {
-        return Storage::disk($this->disk)->url($this->path . FileNamer::encode($this->file_name));
+        return Storage::disk($this->disk)->url($this->path . $this->file_name);
     }
 
     public function getThumbnailUrlAttribute()
@@ -50,7 +50,7 @@ class Media extends Model
         $thumbnailName = $this->conversions[$thumbnailConversionName] ?? null;
         if (!$thumbnailName) return null;
 
-        return Storage::disk($this->conversions_disk)->url($this->conversionsPath . FileNamer::encode($thumbnailName));
+        return Storage::disk($this->conversions_disk)->url($this->conversionsPath . $thumbnailName);
     }
 
     public function formatForNova()


### PR DESCRIPTION
We noticed that filenames for uploaded images are being double-url-encoded - for instance `File-(2).jpg` was decoded as `File-%25282%2529.jpg` instead of  `File-%282%29.jpg`.

This is due to the `->url()` method of `Storage` already URL-encoding.

This PR removes the double encoding, producing working URLs again.