### PR TITLE
Add custom cast for media

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ MediaHubField::make('Media', 'media')
   ->multiple(), // Define whether multiple media can be selected
 ```
 
+### Casting
+
+The media column of models can be automatically cast as a Collection of Media models:
+
+```php
+class Product extends Model
+{
+    protected $casts = [
+        'media' => \Outl1ne\NovaMediaHub\Casts\MediaCast::class,
+    ];
+}
+```
+
+```php
+    $cover = Product::first()->media->first();
+
+    // ...
+
+    $urls = Product::first()->media->pluck('url');
+
+    // ...
+
+    $collection = Product::first()->media->where('collection_name', 'Details');
+```
+
 ### Configure
 
 The config file can be published using the following command:

--- a/src/Casts/MediaCast.php
+++ b/src/Casts/MediaCast.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Outl1ne\NovaMediaHub\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Outl1ne\NovaMediaHub\Models\Media;
+
+class MediaCast implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if (is_null($value)) {
+            return;
+        }
+
+        return Media::whereIn('id', json_decode($value, true))->get();
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value;
+    }
+}


### PR DESCRIPTION
This PR adds a custom cast class which casts the (json) media array as a collection of Media models.

Real world usage example: easily obtaining a list of picture URLs for an API endpoint using `$model->media->pluck('url');`