### PR TITLE
MediaCast bug fixes

### DIFF
--- a/src/Casts/MediaCast.php
+++ b/src/Casts/MediaCast.php
@@ -20,7 +20,12 @@ class MediaCast implements CastsAttributes
     {
         if (is_null($value)) return;
         if (is_numeric($value)) return Media::find($value);
-        return Media::whereIn('id', json_decode($value, true))->get();
+
+        $ids = json_decode($value, true);
+        $order = implode(',', $ids);
+        return Media::whereIn('id', $ids)
+            ->orderByRaw("FIELD(id, $order)")
+            ->get();
     }
 
     /**
@@ -34,6 +39,8 @@ class MediaCast implements CastsAttributes
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        return json_encode($value);
+        if (is_null($value)) return;
+        if (is_array($value)) return json_encode($value);
+        return $value;
     }
 }


### PR DESCRIPTION
- When unselecting/deleting media in Nova, users could run into an issue where json_encode(null) from 9eb577e results in a 'null' (string) value being stored, which would trigger type errors (preventing future saves). Could be related to #63 

- Fixes an issue where media is returned based on ID, not by the sort order defined in Nova

These fixes addressed issues I experienced on projects, but I would recommend testing it out on various scenarios before merging (although it should not have any ill effects)