### PR TITLE
Change file hash building algorithm

### DIFF
--- a/src/MediaHandler/Support/FileHelpers.php
+++ b/src/MediaHandler/Support/FileHelpers.php
@@ -51,7 +51,8 @@ class FileHelpers
 
         try {
             $fileStream = ($disk) ? Storage::disk($disk)->readStream($path) : fopen($path, 'r');
-            $fileHash = md5(fread($fileStream, 1000000));
+            $fileSize = $disk ? Storage::disk($disk)->size($path) : filesize($path);
+            $fileHash = md5($fileSize.fread($fileStream, 1000000));
             fclose($fileStream);
         } catch (Exception $e) {
             return null;


### PR DESCRIPTION
The file hash used to identify duplicates reads only the first 1000000 bytes of a file. Images with the same first part, for example, will end up with the same hash. This update prepends the file size to the file contents prefix, decreasing the collision rate in this type of cases.