### PR TITLE
Add legacy hash support for duplicate checking

### DIFF
--- a/config/nova-media-hub.php
+++ b/config/nova-media-hub.php
@@ -116,4 +116,7 @@ return [
         // 'image/gif',
         // 'image/tiff',
     ],
+
+    // Use legacy hashing algorithm for duplicate file detection, along with the new one, less prone to collisions
+    'check_legacy_hashes' => false,
 ];

--- a/src/MediaHandler/Support/FileHelpers.php
+++ b/src/MediaHandler/Support/FileHelpers.php
@@ -53,6 +53,36 @@ class FileHelpers
             $fileStream = ($disk) ? Storage::disk($disk)->readStream($path) : fopen($path, 'r');
             $fileSize = $disk ? Storage::disk($disk)->size($path) : filesize($path);
             $fileHash = md5($fileSize.fread($fileStream, 1000000));
+
+            fclose($fileStream);
+        } catch (Exception $e) {
+            return null;
+        }
+
+        return $fileHash;
+    }
+
+    /**
+     * Uses only the first 1000000 bytes of the file to generate a hash, which may cause collisions for files with the same beginning.
+     *
+     * @param  string  $path
+     * @param  string|null  $disk
+     *
+     * @return string
+     */
+    public static function getLegacyFileHash(string $path, ?string $disk = null): string
+    {
+        if (! $path) {
+            return null;
+        }
+        if (! $disk && ! is_file($path)) {
+            return null;
+        }
+
+        try {
+            $fileStream = ($disk) ? Storage::disk($disk)->readStream($path) : fopen($path, 'r');
+            $fileHash = md5(fread($fileStream, 1000000));
+
             fclose($fileStream);
         } catch (Exception $e) {
             return null;


### PR DESCRIPTION
Add an option to also check legacy hashes when looking for duplicates.
Check for duplicates only when we should do that.